### PR TITLE
Fix session save on Windows when absolute = true

### DIFF
--- a/lua/sessions/init.lua
+++ b/lua/sessions/init.lua
@@ -32,7 +32,7 @@ end
 -- converts a given filepath to a string safe to be used as a session filename
 local safe_path = function(path)
     if util.windows then
-        return path:gsub(util.path.sep, "."):sub(3)
+        return path:gsub(util.path.sep, "."):sub(4)
     else
         return path:gsub(util.path.sep, "."):sub(2)
     end

--- a/lua/sessions/init.lua
+++ b/lua/sessions/init.lua
@@ -31,7 +31,11 @@ end
 
 -- converts a given filepath to a string safe to be used as a session filename
 local safe_path = function(path)
-    return path:gsub(util.path.sep, "."):sub(2)
+    if util.windows then
+        return path:gsub(util.path.sep, "."):sub(3)
+    else
+        return path:gsub(util.path.sep, "."):sub(2)
+    end
 end
 
 -- given a path (possibly empty or nil) returns the absolute session path or

--- a/lua/sessions/util.lua
+++ b/lua/sessions/util.lua
@@ -1,17 +1,21 @@
 local M = {}
 
+M.windows = (function()
+    if jit then
+        local os = string.lower(jit.os)
+        return os == "windows"
+    else
+        return "\\" == package.config:sub(1, 1)
+    end
+end)()
+
 -- system dependent path separator from plenary.nvim
 M.path = {}
 M.path.sep = (function()
-    if jit then
-        local os = string.lower(jit.os)
-        if os == "linux" or os == "osx" or os == "bsd" then
-            return "/"
-        else
-            return "\\"
-        end
+    if M.windows then
+        return "\\"
     else
-        return package.config:sub(1, 1)
+        return "/"
     end
 end)()
 


### PR DESCRIPTION
I was getting the following error when attempting to save sessions with absolute = true on Windows:

```
E5108: Error executing lua ...te\pack\packer\start\sessions.nvim/lua\sessions\init.lua:68: Vim(mksession):E190: Cannot open "C:\Users\Joshua\AppData\Local\nvim-data\sessions\:.Users.Joshua..config.nvim.session" for writing
stack traceback:
	[C]: in function 'cmd'
	...te\pack\packer\start\sessions.nvim/lua\sessions\init.lua:68: in function 'write_session_file'
	...te\pack\packer\start\sessions.nvim/lua\sessions\init.lua:124: in function 'save'
	...te\pack\packer\start\sessions.nvim/lua\sessions\init.lua:204: in function 'parse_args'
	[string ":lua"]:1: in main chunk

```

There was an bug in the safe_path function causing paths on Windows to have a leading ":". Fix is to simply remove two characters instead of one if the OS is Windows.