### PR TITLE
Add sessions.start_autosave to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ sessions.save(path: string, opts: table)
 
 sessions.load(path: string, opts: table)
 
+sessions.start_autosave()
+
 sessions.stop_autosave(opts: table)
 
 sessions.recording(): bool

--- a/doc/sessions.txt
+++ b/doc/sessions.txt
@@ -110,6 +110,12 @@ options with the following defaults. >
         silent = false,
     }
 
+sessions.start_autosave()
+    Start recording session.
+
+    Note: this does not save session at the point of calling,
+    only initiates recording if it was previously stopped.
+
 sessions.stop_autosave(opts: {table})
     Stop recording and optionally save current session state.
 


### PR DESCRIPTION
Closes #5 

This turned out more complex than I expected 😄

- added `path` param to `write_session_file` so that functions can optionally pick other value than current `session_file_path`
- similarly added an optional `path` param to the new `start_autosave_internal()`, which now should be used to set the `session_file_path` for simpler logic
- fixed a bug that caused `get_session_path(path, false)` to work as `get_session_path(path, true)` because of incorrect logic for the default `ensure` value