### PR TITLE
Add named session support for absolute mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ The setup function accepts a table to modify the default configuration:
     -- treat the default session filepath as an absolute path
     -- if true, all session files will be stored in a single directory
     absolute = false,
+
+    -- enables naming of session for the absolute mode
+    -- meant in particular for cleaner selection in a fuzzy-finder
+    named = false,
 }
 ```
 
@@ -112,6 +116,17 @@ require("sessions").setup({
     events = { "WinEnter" },
     session_filepath = vim.fn.stdpath("data") .. "/sessions",
     absolute = true,
+})
+```
+
+Additionally when named is true, the path argument in commands will be treated as session filename.
+
+```lua
+require("sessions").setup({
+    events = { "WinEnter" },
+    session_filepath = vim.fn.stdpath("data") .. "/sessions",
+    absolute = true,
+    named = true,
 })
 ```
 

--- a/lua/sessions/init.lua
+++ b/lua/sessions/init.lua
@@ -13,6 +13,10 @@ local config = {
     -- treat the default session filepath as an absolute path
     -- if true, all session files will be stored in a single directory
     absolute = false,
+
+    -- enables naming of session for the absolute mode
+    -- meant in particular for cleaner selection in a fuzzy-finder
+    named = false,
 }
 
 local M = {}
@@ -38,9 +42,9 @@ local safe_path = function(path)
     end
 end
 
--- given a path (possibly empty or nil) returns the absolute session path or
--- the default session path if it exists. Will create intermediate directories
--- as needed. Returns nil otherwise.
+-- given a path (possibly empty or nil) returns the absolute session path
+-- or absolute named path, otherwise the default session path if it exists.
+-- Will create intermediate directories as needed. Returns nil otherwise.
 local get_session_path = function(path, ensure)
     if ensure == nil then
         ensure = true
@@ -48,6 +52,12 @@ local get_session_path = function(path, ensure)
 
     if path and path ~= "" then
         path = vim.fn.expand(path, ":p")
+        if config.named
+            and config.absolute
+            and config.session_filepath ~= ""
+            and string.sub(path, 1, 1) ~= util.path.sep then
+            path = vim.fn.expand(config.session_filepath, ":p") .. util.path.sep .. path
+        end
     elseif config.session_filepath ~= "" then
         if config.absolute then
             local cwd = vim.fn.fnamemodify(vim.fn.getcwd(), ":p")


### PR DESCRIPTION
Thanks for the great plugin!

I added this feature to support my workflow, it allows naming sessions when using absolute mode rather than only storing them as paths split by dots. My fuzzy finder now lists named sessions, similar to how the good old [dominickng/fzf-session.vim](https://github.com/dominickng/fzf-session.vim) works.

I'm not sure if this is something you want for this project but I'll leave a PR here just in case.