### PR TITLE
Prevent `mksession` being run within the command-line window

### DIFF
--- a/lua/sessions/init.lua
+++ b/lua/sessions/init.lua
@@ -72,7 +72,9 @@ local session_file_path = nil
 
 local write_session_file = function(path)
     local target_path = path or session_file_path
-    vim.cmd(string.format("mksession! %s", target_path))
+    if vim.fn.getcmdwintype() == "" then
+      vim.cmd(string.format("mksession! %s", target_path))
+    end
 end
 
 local start_autosave_internal = function(path)


### PR DESCRIPTION
Fixes #13

Use `getcmdwintype` to detect if currently in the command-line window, which returns empty string when not in command-line window: [`getcmdwintype`](https://neovim.io/doc/user/builtin.html#getcmdwintype())
